### PR TITLE
Add more input types to change event

### DIFF
--- a/change.js
+++ b/change.js
@@ -1,6 +1,11 @@
 var extend = require('xtend')
 var getFormData = require('form-data-set/element')
 
+var VALID_CHANGE = ['checkbox', 'file'];
+var VALID_INPUT = ['color', 'date', 'datetime', 'datetime-local', 'email',
+    'month', 'number', 'password', 'range', 'search', 'tel', 'text', 'time',
+    'url', 'week'];
+
 module.exports = ChangeSinkHandler
 
 function ChangeSinkHandler(sink, data) {
@@ -29,10 +34,8 @@ function handleEvent(ev) {
     var target = ev.target
 
     var isValid =
-        (ev.type === 'change' && target.type === 'checkbox') ||
-        (ev.type === 'input' && target.type === 'text') ||
-        (ev.type === 'change' && target.type === 'range') ||
-        (ev.type === 'change' && target.type === 'file')
+        (ev.type === 'input' && VALID_INPUT.indexOf(target.type) !== -1) ||
+        (ev.type === 'change' && VALID_CHANGE.indexOf(target.type) !== -1);
 
     if (!isValid) {
         return


### PR DESCRIPTION
This adds more `<input>` types such as password and url to the change event. I tested the additional input types and they all emit the `input` event for Firefox and Chrome (at least the types that are natively supported in each browser, otherwise they report `type` as `text`).

One change is that `range` was moved to using the `input` event, which was emitted in both Firefox and Chrome, so not sure why it was using `change` event before.

Also the tests do not pass in the `master` version, so I couldn't run all the tests. I did test it manually and it seems to work.
