### PR TITLE
Add `preventDefault` to key events

### DIFF
--- a/key.js
+++ b/key.js
@@ -6,6 +6,10 @@ function keyLambda(ev, broadcast) {
     var key = this.opts.key;
 
     if (ev.keyCode === key) {
+        if (this.opts.preventDefault && ev.preventDefault) {
+            ev.preventDefault();
+        }
+
         broadcast(this.data);
     }
 }


### PR DESCRIPTION
Click events already have this option, and it seems only natural that key events should also have them.

Specifically I was having trouble in [mercury] binding the keypress `Enter` in a form `<input type="text">`-field as the keypress was submitting the form as well as sending keypress event over a channel. To avoid the form being submitted I need (I think?) the `preventDefault` functionality.

[mercury]: https://github.com/Raynos/mercury