### PR TITLE
Added filtered event for selectively broadcasting events.

### DIFF
--- a/filter.js
+++ b/filter.js
@@ -1,0 +1,16 @@
+var BaseEvent = require('./base-event.js');
+
+module.exports = BaseEvent(eventLambda);
+
+function eventLambda(ev, broadcast) {
+  var opts = this.opts;
+  var is_valid = false;
+
+  if (opts.event_types && opts.event_types.length) {
+    is_valid = opts.event_types.indexOf(ev.type) >= 0;
+  }
+
+  if (is_valid) {
+    broadcast(this.data);
+  }
+}

--- a/test/filter.js
+++ b/test/filter.js
@@ -1,0 +1,94 @@
+var EventSinks = require('event-sinks/geval')
+var document = require('global/document')
+var test = require('tape')
+var setImmediate = require('timers').setImmediate
+
+var Event = require('./lib/create-event.js')
+var h = require('./lib/h.js')
+var event = require('../filter.js')
+
+test('filter event is a function', function (assert) {
+    assert.equal(typeof event, 'function')
+    assert.end()
+})
+
+test('can add filter event', function (assert) {
+    var elem = h('div')
+    document.body.appendChild(elem)
+    var input = EventSinks('', [
+        'someEvent'
+    ])
+
+    var values = []
+    input.events.someEvent(function (data) {
+        values.push(data)
+    })
+    elem.addEventListener('focusin', event(input.sinks.someEvent, {
+        some: 'data'
+    }, {
+    	event_types: ['focusin']
+    }))
+
+    var ev = Event('focusin')
+    elem.dispatchEvent(ev)
+
+    setImmediate(function () {
+        assert.equal(values.length, 1)
+        assert.equal(values[0].some, 'data')
+
+        document.body.removeChild(elem)
+        assert.end()
+    })
+})
+
+test('can add (function) filter event', function (assert) {
+    var elem = h('div')
+    document.body.appendChild(elem)
+
+    var values = []
+    var sink = function (data) {
+        values.push(data)
+    }
+    elem.addEventListener('focusin', event(sink, {
+        some: 'data'
+    }, {
+    	event_types: ['focusin']
+    }))
+
+    var ev = Event('focusin')
+    elem.dispatchEvent(ev)
+
+    setImmediate(function () {
+        assert.equal(values.length, 1)
+        assert.equal(values[0].some, 'data')
+
+        document.body.removeChild(elem)
+        assert.end()
+    })
+})
+
+
+test('filter event does not fire when does not match filtered types', function (assert) {
+    var elem = h('div')
+    document.body.appendChild(elem)
+
+    var values = []
+    var sink = function (data) {
+        values.push(data)
+    }
+    elem.addEventListener('focusin', event(sink, {
+        some: 'data'
+    }, {
+    	event_types: ['focusin']
+    }))
+
+    var ev = Event('click')
+    elem.dispatchEvent(ev)
+
+    setImmediate(function () {
+    		assert.equal(values.length, 0);
+
+        document.body.removeChild(elem)
+        assert.end()
+    })
+})


### PR DESCRIPTION
## Scenario
I'm working on an app where I need to capture just the focus events (focusin, focusout) for a given input, then modify state.  When using `value-event/event`, I can broadcast and receive the event, but this has 2 problems:

1. Since the original event object and DOM element are de-coupled, I cannot tell what event fired.  I just know that there was AN event.
2. A large number of events are being fired.  Most of them are not important to me.

## Solution
Added `value-event/filter` event.  This works exactly like `value-event/event`except that it takes a whitelist of event names that it will allow to pass.  This allows event targeting without bringing any part of the event or DOM forward into the handler or channel.

# Usage

```
var sendFilteredEvent  = require('value-event/filter.js');

var state = { 
  active: false
};
var active_handler = function(active) {
  state.active = active;
};
var text_handlers = [

  sendFilteredEvent(active_handler, true , {
    event_types: ['focusin']
  }), 

  sendFilteredEvent(active_handler, false, {
    event_types: ['focusout']
  })
];

```

Now the VDOM part
```
h('input', {
  'ev-event': text_handlers,
  name: 'dogs',
  type: 'text'
});

```
